### PR TITLE
Add GetMonitorInfo function for Windows < 8.1 DPI fallback functionality

### DIFF
--- a/w32/user32.go
+++ b/w32/user32.go
@@ -124,6 +124,7 @@ var (
 	procMonitorFromRect               = moduser32.NewProc("MonitorFromRect")
 	procMonitorFromWindow             = moduser32.NewProc("MonitorFromWindow")
 	procGetMonitorInfo                = moduser32.NewProc("GetMonitorInfoW")
+	procGetDpiForSystem               = moduser32.NewProc("GetDpiForSystem")
 	procEnumDisplayMonitors           = moduser32.NewProc("EnumDisplayMonitors")
 	procEnumDisplaySettingsEx         = moduser32.NewProc("EnumDisplaySettingsExW")
 	procChangeDisplaySettingsEx       = moduser32.NewProc("ChangeDisplaySettingsExW")
@@ -1085,6 +1086,11 @@ func MonitorFromWindow(hwnd HWND, dwFlags uint32) HMONITOR {
 		uintptr(dwFlags),
 	)
 	return HMONITOR(ret)
+}
+
+func GetDpiForSystem() uint {
+	ret, _, _ := procGetDpiForSystem.Call()
+	return ret
 }
 
 func GetMonitorInfo(hMonitor HMONITOR, lmpi *MONITORINFO) bool {


### PR DESCRIPTION
Windows 7 Pro is still technically supported, and getting DPI information requires this API call since shcore.dll is unavailable.